### PR TITLE
Support new distribution areas & multiple distributions per course

### DIFF
--- a/controllers/endpoints/search.js
+++ b/controllers/endpoints/search.js
@@ -34,7 +34,15 @@ router.use('/:query', function (req, res) {
   // Perform filtering based on explicit keywords
   let queryWords = req.params.query.split(' ')
   var newQueryWords = []
-  const distributionAreas = ['EC', 'EM', 'HA', 'LA', 'SA', 'QR', 'STL', 'STN']
+  const distributionAreas = ['CD', 'QCR', 'SEL', 'SEN', 'EC', 'EM', 'HA', 'LA', 'SA', 'QR', 'STL', 'STN']
+  const distributionCorresp = {
+    'QCR':'QR',
+    'QR' :'QCR',
+    'SEL':'STL',
+    'STL':'SEL',
+    'SEN':'STN',
+    'STN':'SEN'
+  }
   const courseDeptNumberRegexp = /([A-Z]{3})(\d{1,3})/
   const catalogNumberLevel = /\dXX/i
   let departmentsQueried = []
@@ -56,6 +64,9 @@ router.use('/:query', function (req, res) {
         }
       }
       courseQuery.distribution['$in'].push(thisQueryWord)
+      if(distributionCorresp.hasOwnProperty(thisQueryWord)) {
+        courseQuery.distribution['$in'].push(distributionCorresp[thisQueryWord])
+      }
     } else if (isDepartment) {
       departmentsQueried.push(thisQueryWord)
     } else if (thisQueryWord === 'PDF') {

--- a/controllers/endpoints/search.js
+++ b/controllers/endpoints/search.js
@@ -63,9 +63,9 @@ router.use('/:query', function (req, res) {
           '$in': []
         }
       }
-      courseQuery.distribution['$in'].push(thisQueryWord)
+      courseQuery.distribution['$in'].push(new RegExp(thisQueryWord))
       if(distributionCorresp.hasOwnProperty(thisQueryWord)) {
-        courseQuery.distribution['$in'].push(distributionCorresp[thisQueryWord])
+        courseQuery.distribution['$in'].push(new RegExp(distributionCorresp[thisQueryWord]))
       }
     } else if (isDepartment) {
       departmentsQueried.push(thisQueryWord)

--- a/importers/importBasicCourseDetails.js
+++ b/importers/importBasicCourseDetails.js
@@ -281,6 +281,9 @@ var importSubject = async function (semester, subject) {
       // Get other information
       courseData.website = frontEndApiCourseDetails.web_address
 
+      // Get distribution requirements
+      courseData.distribution_area = frontEndApiCourseDetails.distribution_area_short
+
       courseModel.createCourse(semester, subject.code, courseData, function () {
         // Decrement the number of courses pending processing
         coursesPendingProcessing--

--- a/public/scripts/icon.js
+++ b/public/scripts/icon.js
@@ -124,17 +124,19 @@ function newHTMLtags(course, props) {
 
   /* DISTRIBUTION TAG */
 
-  var hasDistribution = (course.hasOwnProperty('distribution') && (course.distribution in distributions))
-
   var tag_distribution = ''
-  if (hasDistribution) tag_distribution = newHTMLtag(
-    {
-      'tooltip': distributions[course.distribution],
-      'placement': tipPlacement,
-      'class': tag_type + (isTitle ? 'label-info' : 'text-info'),
-      'text': course.distribution
+  if(course.hasOwnProperty('distribution')) {
+    for(distribution in distributionsAll) {
+      if((new RegExp(distribution)).test(course.distribution)) tag_distribution += ' ' + newHTMLtag(
+        {
+          'tooltip': distributionsAll[distribution],
+          'placement': tipPlacement,
+          'class': tag_type + (isTitle ? 'label-info' : 'text-info'),
+          'text': distribution
+        }
+      )
     }
-  )
+  }
 
   /* PDF TAG */
 

--- a/public/scripts/suggest.js
+++ b/public/scripts/suggest.js
@@ -4,14 +4,15 @@
 
 // distributions
 const distributions = {
+  'CD': 'Culture and Difference', 
   'EC': 'Epistemology and Cognition',
   'EM': 'Ethical Thought and Moral Values',
   'HA': 'Historical Analysis',
   'LA': 'Literature and the Arts',
   'SA': 'Social Analysis',
-  'QR': 'Quantitative Reasoning',
-  'STL': 'Science and Technology with Lab',
-  'STN': 'Science and Technology without Lab'
+  'QCR': 'Quantitative and Computational Reasoning',
+  'SEL': 'Science and Engineering with Lab',
+  'SEN': 'Science and Engineering without Lab',
 }
 
 // departments

--- a/public/scripts/suggest.js
+++ b/public/scripts/suggest.js
@@ -15,6 +15,16 @@ const distributions = {
   'SEN': 'Science and Engineering without Lab',
 }
 
+const distributionsOld = {
+  'QR': 'Quantitative REasoning',
+  'STL':'Science and Technology with Lab',
+  'STN':'Science and Technology without Lab'
+}
+
+const distributionsAll = {
+  ...distributions, ...distributionsOld
+}
+
 // departments
 const departments = {
  'AAS': 'African American Studies',


### PR DESCRIPTION
Added support for the new/renamed [distribution areas](https://odoc.princeton.edu/curriculum/general-education-requirements): CD (brand new), QR->QCR, STL->SEL, STN->SEN.
Previously, searching for any of these distribution areas in Fall 2020 and onward would yield no results.

Maintained backward compatibility with the old names (e.g. searching for either "QR" or "QCR" will have the same results).

Added support for courses with more than one distribution area.

Fixed a bug that prevented distribution area information from being imported (since the newly implemented MobileApp API does not provide distribution information, get distribution info from Registrar Front End API instead).

<img width="1591" alt="PC-scrn" src="https://user-images.githubusercontent.com/71896424/128884647-70ae1a25-9718-4af4-8643-d35059974f7b.png">
