### PR TITLE
Reduce padding in course labels to remove overlap

### DIFF
--- a/public/stylesheets/app.css
+++ b/public/stylesheets/app.css
@@ -672,3 +672,8 @@ body {
     left: 10px;
   }
 }
+
+/* Fix course label overlaps - override Bootstrap label padding */
+.label {
+  padding: 0.05em 0.3em;
+}


### PR DESCRIPTION
For narrow browser windows (e.g. mobile view), courses with many labels have overlaps when labels are wrapped to the next line. We can't add top padding to these labels due to flexbox issues, so instead we reduce the overall `.label` padding. This solves the issue of overlap.

| Before | After |
| --- | --- |
| ![](https://user-images.githubusercontent.com/13815069/128958051-4c6739fa-d429-4529-bfa0-b858b36fdc4a.png) | ![](https://user-images.githubusercontent.com/13815069/128958070-cb6b1d7b-792e-42e5-ad01-73cc1d8ad867.png) |