### PR TITLE
Show AI chat panel expanded by default

### DIFF
--- a/views/pages/app.ejs
+++ b/views/pages/app.ejs
@@ -48,7 +48,7 @@
           <li id="feedback-toggle"><a href="#">Feedback</a></li>
           <li id="netid"><a href="#"><%= netid %></a></li>
           <li id="logout" class="active" style="display:none;"><a href="/auth/logout">Logout</a></li>
-          <li id="chat-toggle"><a href="#"><span id="ask-ai-btn"><span class="ask-ai-sparkle">&#10024;</span> ASK AI</span></a></li>
+          <li id="chat-toggle"><a href="#"><span id="ask-ai-btn" class="active"><span class="ask-ai-sparkle">&#10024;</span> ASK AI</span></a></li>
         </ul>
       </div>
     </nav>
@@ -247,8 +247,8 @@
           <% include ../partials/welcomepage.ejs %>
         </div>
       </div>
-      <div id="chat-resizer" class="flex-item-rigid resizer-inactive"></div>
-      <div id="chat-pane" class="flex-container-col slide chat-pane-hidden">
+      <div id="chat-resizer" class="flex-item-rigid resizer"></div>
+      <div id="chat-pane" class="flex-container-col slide">
         <div id="chat-header" class="flex-item-rigid">
           <div id="chat-quota-display">
             <div id="chat-usage-bar">


### PR DESCRIPTION
## Summary
- Remove `chat-pane-hidden` class so the chat panel is visible on page load
- Set resizer to active state and ASK AI button to active styling

## Test plan
- [ ] Verify chat panel is expanded when loading the app
- [ ] Verify toggling chat closed/open still works
- [ ] Verify mobile behavior is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)