### PR TITLE
(bug) prevent evaluation vote underflow

### DIFF
--- a/controllers/endpoints/evaluations.js
+++ b/controllers/endpoints/evaluations.js
@@ -29,23 +29,25 @@ router.route('/:id/vote').all(async function (req, res, next) {
   let user = res.locals.user
 
   try {
-    var evaluation = await evaluationModel.findById(req.params.id).exec()
-
-    // Ensure the user has not already voted on this comment
-    if (typeof (evaluation.voters) !== 'undefined' && evaluation.voters.indexOf(user._id) > -1) {
-      res.sendStatus(403)
-      return
-    }
-
-    // Update the evaluation (increment the number of votes and add the user's netID to the list of voters)
-    await evaluationModel.findByIdAndUpdate(req.params.id, {
+    // Update only if this user has not already voted on this comment
+    var evaluation = await evaluationModel.findOneAndUpdate({
+      _id: req.params.id,
+      voters: {
+        $ne: user._id
+      }
+    }, {
       $inc: {
         votes: 1
       },
       $addToSet: {
         voters: user._id
       }
-    })
+    }).exec()
+
+    if (evaluation === null) {
+      res.sendStatus(403)
+      return
+    }
 
     // Return success to the client
     res.sendStatus(200)
@@ -57,28 +59,23 @@ router.route('/:id/vote').all(async function (req, res, next) {
   let user = res.locals.user
 
   try {
-    var evaluation = await evaluationModel.findById(req.params.id).exec()
-
-    if (typeof (evaluation.voters) === 'undefined') {
-      res.sendStatus(500)
-      return
-    }
-
-    // Ensure the user has already voted on this comment
-    if (!Array.isArray(evaluation.voters) || evaluation.voters.indexOf(user._id) === -1) {
-      res.sendStatus(403)
-      return
-    }
-
-    // Update the evaluation (decrement the number of votes and remove the user's netID from the list of voters)
-    await evaluationModel.findByIdAndUpdate(req.params.id, {
+    // Update only if this user has already voted on this comment
+    var evaluation = await evaluationModel.findOneAndUpdate({
+      _id: req.params.id,
+      voters: user._id
+    }, {
       $inc: {
         votes: -1
       },
       $pull: {
         voters: user._id
       }
-    })
+    }).exec()
+
+    if (evaluation === null) {
+      res.sendStatus(403)
+      return
+    }
 
     // Return success to the client
     res.sendStatus(200)

--- a/controllers/endpoints/evaluations.js
+++ b/controllers/endpoints/evaluations.js
@@ -65,7 +65,7 @@ router.route('/:id/vote').all(async function (req, res, next) {
     }
 
     // Ensure the user has already voted on this comment
-    if (typeof (evaluation.voters) !== 'object' && evaluation.voters.indexOf(user._id) === -1) {
+    if (!Array.isArray(evaluation.voters) || evaluation.voters.indexOf(user._id) === -1) {
       res.sendStatus(403)
       return
     }

--- a/controllers/endpoints/favorites.js
+++ b/controllers/endpoints/favorites.js
@@ -207,7 +207,7 @@ router.route('/:id/vote').all(async function (req, res, next) {
     }
 
     // Ensure the user has already voted on this comment
-    if (typeof (evaluation.voters) !== 'object' && evaluation.voters.indexOf(user._id) === -1) {
+    if (!Array.isArray(evaluation.voters) || evaluation.voters.indexOf(user._id) === -1) {
       res.sendStatus(403)
       return
     }

--- a/controllers/endpoints/favorites.js
+++ b/controllers/endpoints/favorites.js
@@ -171,23 +171,25 @@ router.route('/:id/vote').all(async function (req, res, next) {
   let user = res.locals.user
 
   try {
-    var evaluation = await evaluationModel.findById(req.params.id).exec()
-
-    // Ensure the user has not already voted on this comment
-    if (typeof (evaluation.voters) !== 'undefined' && evaluation.voters.indexOf(user._id) > -1) {
-      res.sendStatus(403)
-      return
-    }
-
-    // Update the evaluation (increment the number of votes and add the user's netID to the list of voters)
-    await evaluationModel.findByIdAndUpdate(req.params.id, {
+    // Update only if this user has not already voted on this comment
+    var evaluation = await evaluationModel.findOneAndUpdate({
+      _id: req.params.id,
+      voters: {
+        $ne: user._id
+      }
+    }, {
       $inc: {
         votes: 1
       },
       $addToSet: {
         voters: user._id
       }
-    })
+    }).exec()
+
+    if (evaluation === null) {
+      res.sendStatus(403)
+      return
+    }
 
     // Return success to the client
     res.sendStatus(200)
@@ -199,28 +201,23 @@ router.route('/:id/vote').all(async function (req, res, next) {
   let user = res.locals.user
 
   try {
-    var evaluation = await evaluationModel.findById(req.params.id).exec()
-
-    if (typeof (evaluation.voters) === 'undefined') {
-      res.sendStatus(500)
-      return
-    }
-
-    // Ensure the user has already voted on this comment
-    if (!Array.isArray(evaluation.voters) || evaluation.voters.indexOf(user._id) === -1) {
-      res.sendStatus(403)
-      return
-    }
-
-    // Update the evaluation (decrement the number of votes and remove the user's netID from the list of voters)
-    await evaluationModel.findByIdAndUpdate(req.params.id, {
+    // Update only if this user has already voted on this comment
+    var evaluation = await evaluationModel.findOneAndUpdate({
+      _id: req.params.id,
+      voters: user._id
+    }, {
       $inc: {
         votes: -1
       },
       $pull: {
         voters: user._id
       }
-    })
+    }).exec()
+
+    if (evaluation === null) {
+      res.sendStatus(403)
+      return
+    }
 
     // Return success to the client
     res.sendStatus(200)


### PR DESCRIPTION
## Summary

- Make evaluation vote add/remove operations conditional and atomic in both duplicated vote routes.
- Increment only when the current user's NetID is not already in `voters`.
- Decrement only when the current user's NetID is already in `voters`.

## Root Cause

The delete guard used `typeof evaluation.voters !== 'object' && evaluation.voters.indexOf(user._id) === -1`. For the normal array case, `typeof voters` is `"object"`, so the left side is false and the whole condition is false even when the user never voted. Any authenticated user could repeatedly delete a vote they did not own, decrementing the public vote count while `$pull` removed nothing.

The add path had the inverse race: it checked `voters` in one query and then incremented in a second query. Concurrent PUTs from the same user could pass the pre-check before `$addToSet` landed, storing the NetID once but incrementing `votes` multiple times.

## Validation

- `node --check controllers/endpoints/evaluations.js`
- `node --check controllers/endpoints/favorites.js`
- `git diff --check`

*(PR Body Written By Codex)*
