### PR TITLE
(bug) redact evaluation voters

### DIFF
--- a/controllers/endpoints/course.js
+++ b/controllers/endpoints/course.js
@@ -8,6 +8,18 @@ let router = express.Router()
 let courseModel = require.main.require('./models/course.js')
 let userModel = require.main.require('./models/user.js')
 
+function redactEvaluationVoters (evaluations, user) {
+  if (!evaluations || !Array.isArray(evaluations.comments)) return
+
+  for (var commentIndex in evaluations.comments) {
+    let comment = evaluations.comments[commentIndex]
+    if (user && Array.isArray(comment.voters)) {
+      comment.voted = comment.voters.indexOf(user._id) > -1
+    }
+    delete comment.voters
+  }
+}
+
 // Allow requesting only the classes information
 // (This is used to allow the rest of the class page to be cached by the client, and only request this information on pageload)
 router.use('/:id/classes', function (req, res) {
@@ -149,14 +161,7 @@ router.use('/:id', function (req, res) {
         })
       }
 
-        // Note if the user has previously up-voted this comment
-      if (res.locals.user) { // if statement needed for chatbot api access
-        for (var commentIndex in queryCourse.evaluations.comments) {
-          queryCourse.evaluations.comments[commentIndex].voted = queryCourse.evaluations.comments[commentIndex].voters.indexOf(res.locals.user._id) > -1
-          delete queryCourse.evaluations.comments[commentIndex].voters
-        }
-        delete queryCourse.evaluations.commonName
-      }
+      delete queryCourse.evaluations.commonName
     } else {
       queryCourse.evaluations = {}
       if (queryCourse.hasOwnProperty('scores')) {
@@ -168,6 +173,7 @@ router.use('/:id', function (req, res) {
         delete queryCourse.comments
       }
     }
+    redactEvaluationVoters(queryCourse.evaluations, res.locals.user)
 
       // Delete the raw comments array from the returned course object.
     delete queryCourse.comments


### PR DESCRIPTION
## Summary

- Always remove raw `voters` arrays from course-detail evaluation comments before returning `/api/course/:id`.
- Preserve the existing logged-in UI behavior by deriving `comment.voted` before redacting voter NetIDs.
- Apply the redaction after both evaluation paths, including the fallback path that copies current-course comments into `queryCourse.evaluations`.

## Root Cause

Evaluation documents store `voters` as NetID strings. The course endpoint only deleted that field inside the logged-in user branch for one evaluation path. Bearer-token callers and the current-course comments fallback could receive `evaluations.comments[*].voters`, exposing the NetIDs of students who voted on comments.

## Validation

- `node --check controllers/endpoints/course.js`
- Local redaction simulation verified anonymous/bearer responses drop `voters`, while logged-in responses keep the derived `voted` boolean.
- `git diff --check`

*(PR Body Written By Codex)*
