### PR TITLE
(bug) require session secret

### DIFF
--- a/controllers/config.js
+++ b/controllers/config.js
@@ -17,8 +17,13 @@ module.exports.host = host
 var port = process.env.PORT || 5050
 module.exports.port = port
 
-// The secret used to encrypt session database
-module.exports.sessionSecret = process.env.SESSION_SECRET || 'abcdefghijklmnop'
+// The secret used to sign session cookies
+var sessionSecret = process.env.SESSION_SECRET
+if (typeof (sessionSecret) !== 'string' || sessionSecret.length < 32) {
+  console.log("A SESSION_SECRET of at least 32 characters is required to sign session cookies.")
+  process.exit(1)
+}
+module.exports.sessionSecret = sessionSecret
 
 // Chatbot API key
 module.exports.chatbotAPIKey = process.env.CHATBOT_API_KEY


### PR DESCRIPTION
## Summary

- Remove the public fallback session signing secret.
- Require `SESSION_SECRET` to be explicitly configured and at least 32 characters before the app starts.

## Root Cause

The app uses `cookie-session`, which stores session data client-side and signs it with `config.sessionSecret`. When `SESSION_SECRET` was missing, the app fell back to the hardcoded value `abcdefghijklmnop`. Any deployment missing the env var would accept cookies signed with a public secret, allowing forged `session.cas.netid` values and account impersonation.

## Validation

- `node --check controllers/config.js`
- `MONGODB_URI=mongodb://localhost/test SESSION_SECRET=12345678901234567890123456789012 node -e "const config=require('./controllers/config'); console.log(config.sessionSecret.length)"`
- `MONGODB_URI=mongodb://localhost/test node -e "require('./controllers/config')"` exits non-zero with the expected configuration error.
- `git diff --check`

*(PR Body Written By Codex)*
