### PR TITLE
(bug) redact mongo uri from logs

### DIFF
--- a/controllers/database.js
+++ b/controllers/database.js
@@ -15,6 +15,6 @@ mongoose.connect(config.mongoDBURI)
     console.log('Connecting to the database succeeded.')
   })
   .catch(function (error) {
-    console.log('Connecting to the database failed. Databse URI: %s, Error: %s.', config.mongoDBURI, error)
+    console.log('Connecting to the database failed. Error: %s.', error)
     process.exit(1)
   })


### PR DESCRIPTION
## Summary

- Stop printing `MONGODB_URI` when the app fails to connect to MongoDB.
- Preserve the existing startup failure behavior and still log the connection error.

## Root Cause

Mongo connection failures logged the full configured Mongo URI. In common Atlas/Heroku setups that URI includes the database username and password, so a transient outage or bad credential could write reusable database credentials into app logs.

## Validation

- `node --check controllers/database.js`
- `git diff --check`

*(PR Body Written By Codex)*
