### PR TITLE
(bug) make course details private cache

### DIFF
--- a/controllers/endpoints/course.js
+++ b/controllers/endpoints/course.js
@@ -175,7 +175,9 @@ router.use('/:id', function (req, res) {
       // Insert the number of users who have favorited this course into the returned course object
     queryCourse.favoritesCount = favoritesCount
 
-    res.set('Cache-Control', 'public, max-age=14400').json(queryCourse)
+    res.set('Cache-Control', 'private, no-cache, no-store, must-revalidate')
+      .set('Vary', 'Cookie, Authorization')
+      .json(queryCourse)
   }).catch(function (err) {
     console.log(err)
     res.sendStatus(500)


### PR DESCRIPTION
## Summary

- Stop marking `/api/course/:id` responses as publicly cacheable.
- Add `Vary: Cookie, Authorization` so authenticated browser and bearer-token callers do not share cached course-detail responses.

## Root Cause

Course-detail responses can include user-specific `evaluations.comments[*].voted` state and are available to both cookie-authenticated users and bearer-token callers. The endpoint still returned `Cache-Control: public, max-age=14400`, so an intermediary cache could serve one caller's vote state to another caller.

## Validation

- `node --check controllers/endpoints/course.js`
- `git diff --check`

*(PR Body Written By Codex)*
